### PR TITLE
Fix SQLAlchemy crash under Python 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,9 @@
 # PostgreSQL driver:contentReference[oaicite:6]{index=6}.
 Flask==2.3.2
 Flask-SQLAlchemy==3.1.1
-SQLAlchemy==2.0.30
+# SQLAlchemy 2.0.30 is incompatible with Python 3.13 due to symbol() changes
+# raised during app start-up. Version 2.0.32 includes the upstream fix.
+SQLAlchemy==2.0.32
 psycopg2-binary==2.9.9
 gunicorn==21.2.0
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- bump SQLAlchemy to 2.0.32 in requirements to resolve symbol replacement crash on Python 3.13
- document the compatibility fix directly in the requirements file comments

## Testing
- not run (dependency-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e578010f88832b83ecd43d1c00c51a