### PR TITLE
Add structured logging, correlation IDs, and client telemetry

### DIFF
--- a/OBSERVABILITY.md
+++ b/OBSERVABILITY.md
@@ -1,0 +1,71 @@
+# Observability & Logging
+
+This application now emits production-friendly JSON logs and exposes health &
+client-side telemetry endpoints suitable for Heroku deployments.
+
+## Runtime configuration
+
+Set the following config vars on Heroku (`heroku config:set ...`):
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `LOG_LEVEL` | `INFO` | Root logging level for application logs. |
+| `REQUEST_LOG_SAMPLE_RATE` | `1.0` | Fraction of requests to log in detail (0.0–1.0). |
+| `RESPONSE_BODY_MAX_BYTES` | `2048` | Maximum response body size included in logs (0 disables). |
+| `SENSITIVE_FIELDS` | `password,token,email,phone` | Comma separated field names redacted from logs. |
+| `CLIENT_LOG_RATE_LIMIT` | `10` | Browser log events allowed per IP in the configured window. |
+| `CLIENT_LOG_WINDOW_SECONDS` | `60` | Rolling window for the client log rate limiter. |
+| `LOG_SLACK_WEBHOOK_URL` | _(unset)_ | Optional Slack webhook for ERROR alerts. |
+| `DATABASE_URL` | _(unset)_ | Neon / Postgres URL (falls back to SQLite if missing/unreachable). |
+
+## Logging format
+
+Application logs are single-line JSON with the following fields:
+
+```
+ts, level, logger, msg, request_id, method, path, status, duration_ms,
+client_ip, user_agent, route, db_time_ms, error_type, error, stack, extra_context
+```
+
+Logs automatically inherit the active correlation ID (`X-Request-ID`). Sensitive
+keys from `SENSITIVE_FIELDS` are replaced with `[REDACTED]` before emission.
+
+## Health & telemetry endpoints
+
+- `GET /health` — returns `{"status": "ok"}` without touching the database.
+- `POST /client-logs` — accepts small browser error payloads, applies rate
+  limiting and redaction, and records them as `client_log` events server-side.
+
+## Browser error collection
+
+Include `/static/client-logger.js` (already referenced by `templates/index.html`)
+when serving pages. The script forwards `window.onerror` and
+`unhandledrejection` events via `navigator.sendBeacon` or a fallback `fetch`
+call to `/client-logs`.
+
+## Deployment tips
+
+- The `Procfile` continues to run `gunicorn app:app`; application-level request
+  logging replaces Gunicorn access logs, so no extra flags are required.
+- Ensure `DATABASE_URL` is configured; the app tolerates temporary outages and
+  logs failures during bootstrap without crashing.
+- Optional: provide `LOG_SLACK_WEBHOOK_URL` to receive critical alerts in Slack.
+
+## Validation
+
+Run tests locally before deployment:
+
+```bash
+pip install -r requirements.txt
+pytest -q
+```
+
+Smoke tests after deployment:
+
+```bash
+curl -i https://nekeyoklama-349f67d5e636.herokuapp.com/health
+curl -i -H "X-Request-ID: demo-123" https://nekeyoklama-349f67d5e636.herokuapp.com/health
+curl -i -X POST -H "Content-Type: application/json" \
+  -d '{"level":"error","message":"client"}' \
+  https://nekeyoklama-349f67d5e636.herokuapp.com/client-logs
+```

--- a/app_logging.py
+++ b/app_logging.py
@@ -1,0 +1,339 @@
+"""Centralised JSON logging configuration and helpers.
+
+This module configures the standard library ``logging`` package to emit
+single-line JSON records that can easily be ingested by log aggregators. It
+also exposes convenience helpers for working with per-request context such as
+correlation IDs. The implementation intentionally avoids heavy third-party
+dependencies so it works well in constrained environments like Heroku dynos.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import os
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, Mapping, Optional
+from urllib import request as urlrequest
+
+# ---------------------------------------------------------------------------
+# Context management
+# ---------------------------------------------------------------------------
+
+_request_id_ctx: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "request_id", default=None
+)
+_request_context_ctx: contextvars.ContextVar[Optional[Dict[str, Any]]] = (
+    contextvars.ContextVar("request_context", default=None)
+)
+
+_REDACTED = "[REDACTED]"
+_SENSITIVE_FIELDS = {
+    field.strip().lower()
+    for field in os.environ.get("SENSITIVE_FIELDS", "password,token,email,phone").split(","
+    )
+    if field.strip()
+}
+
+_JSON_LOG_FIELDS = (
+    "ts",
+    "level",
+    "logger",
+    "msg",
+    "request_id",
+    "method",
+    "path",
+    "status",
+    "duration_ms",
+    "client_ip",
+    "user_agent",
+    "route",
+    "db_time_ms",
+    "error_type",
+    "error",
+    "stack",
+    "extra_context",
+)
+
+
+def get_request_id() -> Optional[str]:
+    """Return the correlation ID for the current request, if any."""
+
+    return _request_id_ctx.get()
+
+
+def set_request_id(request_id: str) -> None:
+    """Associate a correlation ID with the current context."""
+
+    _request_id_ctx.set(request_id)
+    merge_request_context(request_id=request_id)
+
+
+def clear_request_id() -> None:
+    """Clear the request ID for the current context."""
+
+    _request_id_ctx.set(None)
+
+
+def get_request_context() -> Dict[str, Any]:
+    """Return contextual information about the current request."""
+
+    ctx = _request_context_ctx.get()
+    if ctx is None:
+        ctx = {}
+        _request_context_ctx.set(ctx)
+    return ctx
+
+
+def merge_request_context(**kwargs: Any) -> None:
+    """Merge key/value pairs into the current request context."""
+
+    ctx = dict(get_request_context())
+    for key, value in kwargs.items():
+        if value is not None:
+            ctx[key] = value
+    _request_context_ctx.set(ctx)
+
+
+def clear_request_context() -> None:
+    """Remove all contextual information for the current request."""
+
+    _request_context_ctx.set({})
+
+
+# ---------------------------------------------------------------------------
+# Redaction helpers
+# ---------------------------------------------------------------------------
+
+def sensitive_fields() -> Iterable[str]:
+    """Return the set of case-insensitive sensitive field names."""
+
+    return _SENSITIVE_FIELDS
+
+
+def redact_sensitive_data(data: Any, fields: Optional[Iterable[str]] = None) -> Any:
+    """Redact sensitive values from mappings or sequences.
+
+    The function works recursively for nested dictionaries and lists. Scalars
+    are returned unchanged. Keys are compared in a case-insensitive manner.
+    """
+
+    fields_set = {field.lower() for field in (fields or sensitive_fields())}
+
+    if isinstance(data, Mapping):
+        redacted: Dict[Any, Any] = {}
+        for key, value in data.items():
+            lowered = str(key).lower()
+            if lowered in fields_set:
+                redacted[key] = _REDACTED
+            else:
+                redacted[key] = redact_sensitive_data(value, fields_set)
+        return redacted
+    if isinstance(data, (list, tuple, set)):
+        return [redact_sensitive_data(item, fields_set) for item in data]
+    return data
+
+
+# ---------------------------------------------------------------------------
+# JSON logging infrastructure
+# ---------------------------------------------------------------------------
+
+class JSONFormatter(logging.Formatter):
+    """Formatter that renders log records as single-line JSON objects."""
+
+    # Attributes populated by logging.LogRecord that we do not want to surface
+    _RESERVED = {
+        "args",
+        "asctime",
+        "created",
+        "exc_info",
+        "exc_text",
+        "filename",
+        "funcName",
+        "levelname",
+        "levelno",
+        "lineno",
+        "module",
+        "msecs",
+        "message",
+        "msg",
+        "name",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "thread",
+        "threadName",
+    }
+
+    def format(self, record: logging.LogRecord) -> str:
+        timestamp = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        payload: Dict[str, Any] = {
+            "ts": timestamp.isoformat(timespec="milliseconds"),
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+            "request_id": get_request_id(),
+            "stack": None,
+            "extra_context": None,
+        }
+
+        # Start from request-scoped context
+        for key, value in get_request_context().items():
+            if key not in payload or payload[key] is None:
+                payload[key] = value
+
+        # Include well-known attributes if present on the record
+        for field in (
+            "method",
+            "path",
+            "status",
+            "duration_ms",
+            "client_ip",
+            "user_agent",
+            "route",
+            "db_time_ms",
+            "error_type",
+            "error",
+        ):
+            value = getattr(record, field, None)
+            if value is not None:
+                payload[field] = value
+
+        # Handle exceptions
+        if record.exc_info:
+            payload["error_type"] = record.exc_info[0].__name__
+            payload["error"] = str(record.exc_info[1])
+            payload["stack"] = self.formatException(record.exc_info)
+        elif getattr(record, "stack_info", None):
+            payload["stack"] = record.stack_info
+
+        extra: Dict[str, Any] = {}
+        for key, value in record.__dict__.items():
+            if key in self._RESERVED or key in payload or key.startswith("_"):
+                continue
+            extra[key] = value
+
+        if extra:
+            payload["extra_context"] = redact_sensitive_data(extra)
+
+        # Ensure every expected field exists for downstream consumers
+        for field in _JSON_LOG_FIELDS:
+            payload.setdefault(field, None)
+
+        return json.dumps(payload, default=_json_default, separators=(",", ":"))
+
+
+def _json_default(obj: Any) -> Any:
+    """JSON serialiser fallback."""
+
+    if isinstance(obj, (datetime,)):
+        return obj.isoformat()
+    return str(obj)
+
+
+class SlackWebhookHandler(logging.Handler):
+    """Optional handler that posts error logs to a Slack incoming webhook."""
+
+    def __init__(self, webhook_url: str, timeout: float = 2.0) -> None:
+        super().__init__(level=logging.ERROR)
+        self.webhook_url = webhook_url
+        self.timeout = timeout
+        self._lock = threading.Lock()
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            payload = {
+                "text": f"[{record.levelname}] {record.getMessage()} (request_id={get_request_id()})"
+            }
+            data = json.dumps(payload).encode("utf-8")
+            req = urlrequest.Request(self.webhook_url, data=data, method="POST")
+            req.add_header("Content-Type", "application/json")
+            with self._lock:
+                urlrequest.urlopen(req, timeout=self.timeout)
+        except Exception:  # pragma: no cover - never break logging on failure
+            self.handleError(record)
+
+
+_configured = False
+
+
+def configure_logging() -> None:
+    """Configure root logging with a JSON formatter."""
+
+    global _configured
+    if _configured:
+        return
+
+    level_name = os.environ.get("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+
+    handler = logging.StreamHandler(stream=sys.stdout)
+    handler.setFormatter(JSONFormatter())
+
+    root = logging.getLogger()
+    root.setLevel(level)
+    root.handlers = [handler]
+    logging.captureWarnings(True)
+
+    # Silence noisy third-party loggers; application middleware emits
+    # request/response logs explicitly.
+    for noisy_logger in (
+        "gunicorn",
+        "gunicorn.access",
+        "gunicorn.error",
+        "uvicorn",
+        "uvicorn.access",
+        "uvicorn.error",
+    ):
+        log = logging.getLogger(noisy_logger)
+        log.handlers = []
+        log.propagate = True
+        log.setLevel(logging.WARNING)
+
+    webhook_url = os.environ.get("LOG_SLACK_WEBHOOK_URL")
+    if webhook_url:
+        root.addHandler(SlackWebhookHandler(webhook_url))
+
+    _configured = True
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger instance using the configured JSON formatter."""
+
+    configure_logging()
+    logger = logging.getLogger(name)
+    return logger
+
+
+# Convenience to track database timings via context manager
+class DBTimer:
+    """Simple helper to track database time and expose it in logs."""
+
+    def __enter__(self) -> "DBTimer":  # pragma: no cover - trivial
+        self._start = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - trivial
+        duration = (time.perf_counter() - getattr(self, "_start", time.perf_counter())) * 1000
+        merge_request_context(db_time_ms=round(duration, 2))
+
+
+__all__ = [
+    "DBTimer",
+    "clear_request_context",
+    "clear_request_id",
+    "configure_logging",
+    "get_logger",
+    "get_request_context",
+    "get_request_id",
+    "merge_request_context",
+    "redact_sensitive_data",
+    "sensitive_fields",
+    "set_request_id",
+]

--- a/correlation_id_middleware.py
+++ b/correlation_id_middleware.py
@@ -1,0 +1,43 @@
+"""Correlation ID middleware for Flask applications."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Optional
+
+from flask import Flask, g, request
+
+from app_logging import clear_request_context, clear_request_id, merge_request_context, set_request_id
+
+HEADER_NAME = "X-Request-ID"
+
+
+def _incoming_request_id() -> Optional[str]:
+    header_val = request.headers.get(HEADER_NAME, "").strip()
+    return header_val or None
+
+
+def init_correlation_id(app: Flask) -> None:
+    """Register handlers that attach a correlation ID to each request."""
+
+    @app.before_request
+    def _assign_request_id() -> None:
+        request_id = _incoming_request_id() or str(uuid.uuid4())
+        set_request_id(request_id)
+        merge_request_context(request_id=request_id)
+        g.request_id = request_id
+
+    @app.after_request
+    def _append_request_id(response):
+        request_id = getattr(g, "request_id", None) or _incoming_request_id()
+        if request_id:
+            response.headers[HEADER_NAME] = request_id
+        return response
+
+    @app.teardown_request
+    def _teardown_request(_exc):
+        clear_request_id()
+        clear_request_context()
+
+
+__all__ = ["init_correlation_id", "HEADER_NAME"]

--- a/db_utils.py
+++ b/db_utils.py
@@ -1,0 +1,49 @@
+"""Database resilience helpers."""
+
+from __future__ import annotations
+
+import time
+from typing import Callable, TypeVar
+
+from app_logging import get_logger
+
+T = TypeVar("T")
+
+_logger = get_logger("app.db")
+
+
+def retry_with_backoff(
+    func: Callable[[], T],
+    attempts: int = 3,
+    base_delay: float = 0.1,
+    max_total_delay: float = 2.0,
+) -> T:
+    """Retry ``func`` with exponential backoff.
+
+    The helper is intentionally simple and synchronous. It avoids exceeding the
+    configured ``max_total_delay`` to keep application start-up fast.
+    """
+
+    last_exc: Exception | None = None
+    total_delay = 0.0
+    for attempt in range(1, attempts + 1):
+        try:
+            return func()
+        except Exception as exc:  # pragma: no cover - behaviour validated via logs
+            last_exc = exc
+            _logger.warning(
+                "transient operation failed", extra={"attempt": attempt, "error": str(exc)}
+            )
+            if attempt >= attempts or total_delay >= max_total_delay:
+                break
+            delay = min(base_delay * (2 ** (attempt - 1)), max_total_delay - total_delay)
+            if delay <= 0:
+                continue
+            time.sleep(delay)
+            total_delay += delay
+    if last_exc:
+        raise last_exc
+    raise RuntimeError("retry_with_backoff failed without exception")
+
+
+__all__ = ["retry_with_backoff"]

--- a/request_logging_middleware.py
+++ b/request_logging_middleware.py
@@ -1,0 +1,147 @@
+"""Request/response logging middleware for Flask."""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+from typing import Any, Dict
+
+from flask import Flask, Response, g, request
+
+from app_logging import get_logger, merge_request_context, redact_sensitive_data
+from correlation_id_middleware import HEADER_NAME
+
+_DEFAULT_SAMPLE_RATE = 1.0
+_DEFAULT_MAX_BYTES = 2048
+
+_request_logger = get_logger("app.request")
+
+
+def _sample_rate() -> float:
+    try:
+        return max(0.0, min(1.0, float(os.environ.get("REQUEST_LOG_SAMPLE_RATE", _DEFAULT_SAMPLE_RATE))))
+    except ValueError:
+        return _DEFAULT_SAMPLE_RATE
+
+
+def _max_response_bytes() -> int:
+    try:
+        return max(0, int(os.environ.get("RESPONSE_BODY_MAX_BYTES", _DEFAULT_MAX_BYTES)))
+    except ValueError:
+        return _DEFAULT_MAX_BYTES
+
+
+def _client_ip() -> str:
+    forwarded = request.headers.get("X-Forwarded-For", "")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.remote_addr or "unknown"
+
+
+def _should_skip(path: str) -> bool:
+    return path.startswith("/static") or path.startswith("/_static") or path in {"/health"}
+
+
+def _should_log_request(path: str) -> bool:
+    if _should_skip(path):
+        return False
+    sample_rate = _sample_rate()
+    if sample_rate >= 1.0:
+        return True
+    return random.random() <= sample_rate
+
+
+def _extract_request_payload() -> Dict[str, Any]:
+    payload: Dict[str, Any] = {}
+    try:
+        if request.args:
+            payload["query"] = redact_sensitive_data(request.args.to_dict(flat=False))
+        if request.method in {"POST", "PUT", "PATCH", "DELETE"}:
+            json_body = request.get_json(silent=True)
+            if json_body is not None:
+                payload["json"] = redact_sensitive_data(json_body)
+    except Exception:
+        payload["body_error"] = "unavailable"
+    return payload
+
+
+def _truncate_response_body(resp: Response) -> str | None:
+    if resp.direct_passthrough:
+        return None
+    try:
+        body = resp.get_data(as_text=True)
+    except Exception:
+        return None
+    if body and resp.mimetype and 'json' in resp.mimetype:
+        try:
+            json_body = json.loads(body)
+            body = json.dumps(redact_sensitive_data(json_body))
+        except Exception:
+            pass
+    limit = _max_response_bytes()
+    if limit == 0 or body is None:
+        return None
+    if len(body) > limit:
+        truncated = body[:limit] + f"... truncated {len(body) - limit} bytes"
+        return truncated
+    return body
+
+
+def init_request_logging(app: Flask) -> None:
+    """Register Flask hooks that emit structured request/response logs."""
+
+    @app.before_request
+    def _log_request_start() -> None:
+        should_log = _should_log_request(request.path)
+        g._log_request = should_log
+        g._request_start = time.perf_counter()
+        merge_request_context(
+            method=request.method,
+            path=request.path,
+            client_ip=_client_ip(),
+            user_agent=request.headers.get("User-Agent"),
+            route=request.url_rule.rule if request.url_rule else None,
+        )
+        if not should_log:
+            return
+        payload = _extract_request_payload()
+        _request_logger.info(
+            "request_start",
+            extra={
+                "event": "request_start",
+                "method": request.method,
+                "path": request.path,
+                "client_ip": _client_ip(),
+                "user_agent": request.headers.get("User-Agent"),
+                "route": request.url_rule.rule if request.url_rule else None,
+                "request_payload": payload,
+            },
+        )
+
+    @app.after_request
+    def _log_request_end(response: Response) -> Response:
+        merge_request_context(status=response.status_code)
+        duration_ms = None
+        if hasattr(g, "_request_start"):
+            duration_ms = (time.perf_counter() - g._request_start) * 1000
+            merge_request_context(duration_ms=round(duration_ms, 2))
+        if getattr(g, "_log_request", False):
+            response_body = _truncate_response_body(response)
+            extra = {
+                "event": "request_end",
+                "status": response.status_code,
+                "duration_ms": round(duration_ms, 2) if duration_ms is not None else None,
+                "route": request.url_rule.rule if request.url_rule else None,
+                "response_body": response_body,
+                "response_headers": {
+                    k: v for k, v in response.headers.items() if k.lower() not in {"set-cookie"}
+                },
+            }
+            _request_logger.info("request_end", extra=extra)
+        response.headers.setdefault(HEADER_NAME, getattr(g, "request_id", ""))
+        return response
+
+
+__all__ = ["init_request_logging"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ SQLAlchemy==2.0.32
 psycopg2-binary==2.9.9
 gunicorn==21.2.0
 python-dotenv==1.0.1
+pytest==8.2.0

--- a/static/client-logger.js
+++ b/static/client-logger.js
@@ -1,0 +1,70 @@
+// Minimal client-side error reporter that forwards errors to /client-logs.
+(function () {
+    const ENDPOINT = '/client-logs';
+    const MAX_MESSAGE_LENGTH = 500;
+
+    function truncate(value) {
+        if (typeof value !== 'string') {
+            return value;
+        }
+        return value.length > MAX_MESSAGE_LENGTH ? value.slice(0, MAX_MESSAGE_LENGTH) + '…' : value;
+    }
+
+    function send(payload) {
+        try {
+            const body = JSON.stringify(payload);
+            if (navigator.sendBeacon) {
+                const blob = new Blob([body], { type: 'application/json' });
+                navigator.sendBeacon(ENDPOINT, blob);
+            } else {
+                fetch(ENDPOINT, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body,
+                    keepalive: true,
+                }).catch(() => {});
+            }
+        } catch (err) {
+            // Swallow errors to avoid impacting the host page.
+        }
+    }
+
+    function buildPayload(level, message, metadata) {
+        return {
+            level,
+            message: truncate(message || ''),
+            url: window.location.href,
+            ua: navigator.userAgent,
+            ts: new Date().toISOString(),
+            stack: truncate(metadata && metadata.stack ? String(metadata.stack) : ''),
+            extra: metadata && metadata.extra ? metadata.extra : undefined,
+        };
+    }
+
+    window.addEventListener('error', function (event) {
+        const payload = buildPayload('error', event.message || 'Script error', {
+            stack: event.error && event.error.stack,
+            extra: {
+                filename: event.filename,
+                lineno: event.lineno,
+                colno: event.colno,
+            },
+        });
+        send(payload);
+    });
+
+    window.addEventListener('unhandledrejection', function (event) {
+        let message = 'Unhandled promise rejection';
+        let stack = '';
+        if (event.reason) {
+            if (typeof event.reason === 'string') {
+                message = event.reason;
+            } else if (event.reason.message) {
+                message = event.reason.message;
+            }
+            stack = event.reason && event.reason.stack ? event.reason.stack : '';
+        }
+        const payload = buildPayload('error', message, { stack });
+        send(payload);
+    });
+})();

--- a/templates/index.html
+++ b/templates/index.html
@@ -64,6 +64,7 @@
         </div>
     </div>
 
+    <script src="{{ url_for('static', filename='client-logger.js') }}" defer></script>
     <script src="{{ url_for('static', filename='app.js') }}"></script>
 </body>
 </html>

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,68 @@
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Generator
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import create_app
+from correlation_id_middleware import HEADER_NAME
+from models import db
+
+
+@pytest.fixture
+def app(monkeypatch: pytest.MonkeyPatch) -> Generator:
+    monkeypatch.setenv('CLIENT_LOG_RATE_LIMIT', '2')
+    monkeypatch.setenv('CLIENT_LOG_WINDOW_SECONDS', '60')
+    monkeypatch.setenv('REQUEST_LOG_SAMPLE_RATE', '1')
+    os.environ.pop('DATABASE_URL', None)
+    application = create_app()
+    application.config.update(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI='sqlite:///:memory:',
+        SERVER_NAME='testserver',
+    )
+    with application.app_context():
+        db.create_all()
+    yield application
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_health_endpoint(client):
+    response = client.get('/health')
+    assert response.status_code == 200
+    assert response.get_json() == {'status': 'ok'}
+
+
+def test_request_id_propagation(client):
+    response = client.get('/health', headers={HEADER_NAME: 'test-id-123'})
+    assert response.headers.get(HEADER_NAME) == 'test-id-123'
+
+
+def test_error_handler_returns_problem_details(client):
+    response = client.get('/api/students')
+    data = response.get_json()
+    assert response.status_code == 400
+    assert data['status'] == 400
+    assert data['title']
+    assert data['detail']
+    assert data['request_id']
+
+
+def test_client_logs_ingestion_and_rate_limit(client):
+    payload = {'level': 'error', 'message': 'client failure'}
+    accepted = client.post('/client-logs', data=json.dumps(payload), content_type='application/json')
+    assert accepted.status_code == 202
+    second = client.post('/client-logs', data=json.dumps(payload), content_type='application/json')
+    assert second.status_code == 202
+    third = client.post('/client-logs', data=json.dumps(payload), content_type='application/json')
+    assert third.status_code == 429
+    data = third.get_json()
+    assert data['status'] == 429


### PR DESCRIPTION
## Summary
- add an app_logging module with JSON log configuration, redaction, optional Slack alerts, and request context helpers
- introduce correlation ID and request logging middleware plus global error handling with Problem Details responses
- expose /health and /client-logs endpoints, ship a browser error reporter, harden DB startup with retries, and document observability configuration

## Testing
- pytest -q *(fails locally: Flask dependency unavailable in the sandbox and pip installs are blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68e57a5d58d4832bbd3e96006a18bfd9